### PR TITLE
Fix Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -9,7 +9,7 @@ $(PROG): $(OBJS)
 	gcc -g -Wall -Wextra -o $@ $^
 
 .c.o:
-	gcc -g -c -o $@ $^
+	gcc -g -Wall -Wextra -c -o $@ $^
 
 clean:
 	rm -rf $(PROG) $(OBJS)

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,7 +9,7 @@ $(PROG): $(OBJS)
 	gcc -g -Wall -Wextra -o $@ $^
 
 .c.o:
-	gcc -g -Wall -Wextra -c -o $@ $<
+	gcc -Wall -Wextra -c -o $@ $<
 
 clean:
 	rm -rf $(PROG) $(OBJS)

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,8 +8,8 @@ all: $(PROG)
 $(PROG): $(OBJS)
 	gcc -g -Wall -Wextra -o $@ $^
 
-.o:
-	gcc -g -c $@
+.c.o:
+	gcc -g -c -o $@ $^
 
 clean:
 	rm -rf $(PROG) $(OBJS)

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,7 +9,7 @@ $(PROG): $(OBJS)
 	gcc -g -Wall -Wextra -o $@ $^
 
 .c.o:
-	gcc -Wall -Wextra -c -o $@ $<
+	gcc -g -Wall -Wextra -c -o $@ $<
 
 clean:
 	rm -rf $(PROG) $(OBJS)

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,7 +9,7 @@ $(PROG): $(OBJS)
 	gcc -g -Wall -Wextra -o $@ $^
 
 .c.o:
-	gcc -g -Wall -Wextra -c -o $@ $^
+	gcc -g -Wall -Wextra -c -o $@ $<
 
 clean:
 	rm -rf $(PROG) $(OBJS)


### PR DESCRIPTION
Makefile の修正

- `.o:` → `.c.o:`
- `.c.o` ルールに入力ファイル `$<` が指定されていなかったのを修正
- リンク時に指定している `-Wall -Wextra` オプションをコンパイル時にも指定
