### PR TITLE
Refine Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,17 +3,18 @@ TEST := test
 SRCS := $(wildcard ./**/*.c)
 OBJS := $(SRCS:%.c=%.o)
 DEFS := $(SRCS:%.c=%.gen.h)
+CFLAGS ?= -g -Wall -Wextra
 
 all: $(PROG) $(TEST)
 
 $(PROG): $(OBJS) main.c
-	gcc -g -Wall -Wextra -o $@ $^
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^
 
 $(TEST): $(OBJS) test.c
-	gcc -g -Wall -Wextra -o $@ $^
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^
 
 .c.o:
-	gcc -g -Wall -Wextra -c -o $@ $<
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
 
 clean:
 	rm -rf $(PROG) $(OBJS) *.dSYM


### PR DESCRIPTION
Makefileの暗黙変数を使うようにしました。
これによって、Makefileを編集しなくても、別のコンパイラを使用したり、コンパイラのオプションを変更したりすることができます。

変数の意味は以下の通り。

* `CC` : Cコンパイラの名前。初期値は`cc`。
* `CFLAGS` : Cコンパイラに渡すオプションのうち、コンパイラ自身が利用するもの。
(ex: `-Wall`)
* `CPPFLAGS` : Cコンパイラに渡すオプションのうち、Cプリプロセッサが利用するもの。 
(ex: `-I/usr/local/include`)
* `LDFLAGS` : Cコンパイラに渡すオプションのうち、リンカが使用するもの。
(ex: `-L/usr/local/lib`)

参考:http://www.ecoop.net/coop/translated/GNUMake3.77/make_10.jp.html#SEC92