### PR TITLE
Fix malloc size is wrong

### DIFF
--- a/src/render/context.c
+++ b/src/render/context.c
@@ -19,7 +19,7 @@ typedef struct _context {
 
 void context_read_file(context *context, char *filename) // PUBLIC;
 {
-  (*context).filename = malloc(strlen(filename));
+  (*context).filename = malloc(strlen(filename)+1);
   strcpy((*context).filename, filename);
   (*context).lines = file_read((*context).filename);
 }


### PR DESCRIPTION
(自分も今まで知らなかったのですが)`strlen`が返す文字列の長さには、終端のナル文字は含まれていません。
つまり、ある文字列に対する`strlen`が返す値をそのまま`malloc`に渡してしまうと、確保された領域は元の文字列をコピーするには1バイトだけ長さが足りないことになり、バッファオーバーフローが起きます。

1バイト程度では強制終了することはまず無いので、「転ばぬ先の杖」程度のものです。

参考までに`AddressSanitizer`が吐き出したエラーを載せておきます。
上の方にバックトレースが載っていて、ここからバッファオーバーフローの犯人が大体わかります。
```
==56347==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60200000ef38 at pc 0x00010ecd21c4 bp 0x7fff51c63690 sp 0x7fff51c62e50
WRITE of size 9 at 0x60200000ef38 thread T0
    #0 0x10ecd21c3 in wrap_strcpy (libclang_rt.asan_osx_dynamic.dylib+0x451c3)
    #1 0x10df9f94b in context_read_file context.c:23
    #2 0x10dfa5837 in main main.c:33
    #3 0x7fff94b28254 in start (libdyld.dylib+0x5254)

0x60200000ef38 is located 0 bytes to the right of 8-byte region [0x60200000ef30,0x60200000ef38)
allocated by thread T0 here:
    #0 0x10ecd7bf0 in wrap_malloc (libclang_rt.asan_osx_dynamic.dylib+0x4abf0)
    #1 0x10df9f8d0 in context_read_file context.c:22
    #2 0x10dfa5837 in main main.c:33
    #3 0x7fff94b28254 in start (libdyld.dylib+0x5254)

SUMMARY: AddressSanitizer: heap-buffer-overflow (libclang_rt.asan_osx_dynamic.dylib+0x451c3) in wrap_strcpy
Shadow bytes around the buggy address:
  0x1c0400001d90: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c0400001da0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c0400001db0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c0400001dc0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c0400001dd0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x1c0400001de0: fa fa fa fa fa fa 00[fa]fa fa 00 06 fa fa 00 00
  0x1c0400001df0: fa fa 00 06 fa fa 00 07 fa fa fd fd fa fa fd fd
  0x1c0400001e00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c0400001e10: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c0400001e20: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c0400001e30: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Heap right redzone:      fb
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack partial redzone:   f4
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==56347==ABORTING
```