### PR TITLE
Fix warning by cppcheck

### DIFF
--- a/src/render/render.c
+++ b/src/render/render.c
@@ -80,7 +80,7 @@ void debug_print_lines(context context) {
     printf("#%lluw %llup", current_lines->width_count, current_lines->position_count);
     while (current_mutable_string) {
       i = 0;
-      printf("[%db,%dp]", current_mutable_string->byte_count, current_mutable_string->position_count);
+      printf("[%ub,%up]", current_mutable_string->byte_count, current_mutable_string->position_count);
       while (i < current_mutable_string->byte_count) {
         if (is_break(&current_mutable_string->string[i])) {
           printf("<BR>");

--- a/src/test_src/test_mutable_string.c
+++ b/src/test_src/test_mutable_string.c
@@ -5,7 +5,7 @@ void test_mutable_string_print(mutable_string *ms) // PUBLIC;
 {
   while (ms) {
     uint i = 0;
-    printf(" - byte_count: %d\n", ms->byte_count);
+    printf(" - byte_count: %u\n", ms->byte_count);
     printf(" - string: ");
     while (i < ms->byte_count) {
       if (is_break(&ms->string[i])) {
@@ -60,13 +60,13 @@ void test_mutable_string(void) // PUBLIC;
   uint byte;
   mutable_string *select = NULL;
   select = mutable_string_select_position_x(ms, 39, &byte);
-  printf("pos -> byte %d\n", byte);
+  printf("pos -> byte %u\n", byte);
   test_mutable_string_print(select);
   select = mutable_string_select_position_x(ms, 40, &byte);
-  printf("pos -> byte %d\n", byte);
+  printf("pos -> byte %u\n", byte);
   test_mutable_string_print(select);
   select = mutable_string_select_position_x(ms, 41, &byte);
-  printf("pos -> byte %d\n", byte);
+  printf("pos -> byte %u\n", byte);
   if (!select) {
     printf("should null\n");
   }

--- a/src/test_src/test_utf8char.c
+++ b/src/test_src/test_utf8char.c
@@ -3,7 +3,7 @@
 void test_utf8char_print(utf8char uc) // PUBLIC;
 {
   uint s = safed_utf8char_size(uc);
-  printf("- size %d\n", s);
+  printf("- size %u\n", s);
   printf("- char ");
   if (is_break(uc)) {
     printf("\\n");
@@ -15,7 +15,7 @@ void test_utf8char_print(utf8char uc) // PUBLIC;
     }
   }
   printf("\n");
-  printf("- width %d\n", utf8char_width(uc));
+  printf("- width %u\n", utf8char_width(uc));
 }
 
 void test_utf8char(void) // PUBLIC;

--- a/src/type/utf8char_type.c
+++ b/src/type/utf8char_type.c
@@ -16,7 +16,6 @@ utf8char utf8char_malloc(void) // PUBLIC;
 void utf8char_free(utf8char uc) // PUBLIC;
 {
   free(uc);
-  uc = NULL;
 }
 
 utf8char utf8char_zero_clear(utf8char uc) // PUBLIC;


### PR DESCRIPTION
Cppcheckで指摘された点を直しました。
- `printf`の変換指定
`unsigned int`に対して使うべき変換指定子は`\d`ではなく`\u`です。
`\d`を使うと、変数が一定以上の値を取るとき異なる値が出力されます。
また、型と異なる変換指定子を使うと規格上は未定義動作となります。

- `utf8char_free`内の`NULL`代入
ポインタ自体は値渡しなので、関数内で変更を加えても意味がありません。
面倒ですが、`utf8char_free`を呼んだ関数の方で`NULL`を代入してください。