### PR TITLE
Fix warning by clang-static-analyzer

### DIFF
--- a/src/file/writer.c
+++ b/src/file/writer.c
@@ -9,10 +9,9 @@ void file_write(const char *filepath, lines *head) // PUBLIC;
   }
 
   lines *current_lines = head;
-  mutable_string *current_mutable_string = head->mutable_string;
 
   while (current_lines) {
-    current_mutable_string = current_lines->mutable_string;
+    mutable_string *current_mutable_string = current_lines->mutable_string;
     while (current_mutable_string) {
       fwrite(current_mutable_string->string, sizeof current_mutable_string->string[0],
              current_mutable_string->byte_count, fp);

--- a/src/render/render_body.c
+++ b/src/render/render_body.c
@@ -8,14 +8,13 @@ void render_body(context context) // PUBLIC;
   int height = context.body_height;
   int render_max_height = context.render_start_height + height;
   lines *current_lines = context.lines;
-  mutable_string *current_mutable_string = context.lines->mutable_string;
   cursor c = cursor_sort_start_end(context.cursor);
 
   unum pos_x = 1;
   unum pos_y = 1;
   unum wrote_byte;
   while (current_lines) {
-    current_mutable_string = current_lines->mutable_string;
+    mutable_string *current_mutable_string = current_lines->mutable_string;
     while (current_mutable_string) {
       wrote_byte = 0;
       if (current_lines->position_count <= 1 && c.start_position_y == pos_y) {


### PR DESCRIPTION
いずれも初期化時に値を代入しているのですが、直後に必ずもう一度代入があるので初期値が利用されていません。
見たところwhile文内でしか使わない変数のようだったので、宣言の位置をループ内に移動しました。